### PR TITLE
Add support for reading the id3 from a stream reader

### DIFF
--- a/id3v2.go
+++ b/id3v2.go
@@ -82,9 +82,7 @@ func OpenFile(file *os.File, opts Options) (*Tag, error) {
 	return parseTag(file, opts)
 }
 
-// OpenStream parses opened stream and finds tag in it considering opts.
-// If there is no tag in stream, OpenStream will create new one with version ID3v2.4.
-// you can use WriteTo to get the metadata
-func OpenStream(stream io.Reader, opts Options) (*Tag, error) {
+// ParseReader parses opened stream and finds tag in it considering opts.
+func ParseReader(stream io.Reader, opts Options) (*Tag, error) {
 	return parseTag(stream, opts)
 }

--- a/id3v2.go
+++ b/id3v2.go
@@ -6,6 +6,7 @@
 package id3v2
 
 import (
+	"io"
 	"os"
 
 	"github.com/bogem/id3v2/util"
@@ -79,4 +80,11 @@ func Open(name string, opts Options) (*Tag, error) {
 // If there is no tag in file, OpenFile will create new one with version ID3v2.4.
 func OpenFile(file *os.File, opts Options) (*Tag, error) {
 	return parseTag(file, opts)
+}
+
+// OpenStream parses opened stream and finds tag in it considering opts.
+// If there is no tag in stream, OpenStream will create new one with version ID3v2.4.
+// you can use WriteTo to get the metadata
+func OpenStream(stream io.Reader, opts Options) (*Tag, error) {
+	return parseTag(stream, opts)
 }

--- a/parse.go
+++ b/parse.go
@@ -25,14 +25,14 @@ type frameHeader struct {
 	BodySize int64
 }
 
-func parseTag(reader io.Reader, opts Options) (*Tag, error) {
-	if reader == nil {
+func parseTag(rd io.Reader, opts Options) (*Tag, error) {
+	if rd == nil {
 		return nil, errors.New("reader is nil")
 	}
 
-	header, err := parseHeader(reader)
+	header, err := parseHeader(rd)
 	if err == errNoTag {
-		return newTag(reader, 0, 4), nil
+		return newTag(rd, 0, 4), nil
 	}
 	if err != nil {
 		return nil, errors.New("error by parsing tag header: " + err.Error())
@@ -42,7 +42,7 @@ func parseTag(reader io.Reader, opts Options) (*Tag, error) {
 		return nil, err
 	}
 
-	t := newTag(reader, tagHeaderSize+header.FramesSize, header.Version)
+	t := newTag(rd, tagHeaderSize+header.FramesSize, header.Version)
 	if opts.Parse {
 		err = t.parseAllFrames(opts)
 	}

--- a/tag.go
+++ b/tag.go
@@ -6,6 +6,7 @@ package id3v2
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"os"
 
@@ -18,7 +19,9 @@ type Tag struct {
 	frames    map[string]Framer
 	sequences map[string]*sequence
 
-	file         *os.File
+	reader io.Reader
+	file   *os.File
+
 	originalSize int64
 	version      byte
 }
@@ -263,6 +266,10 @@ func (t *Tag) SetVersion(version byte) {
 // Save writes t to the file. If there are no frames in tag, Save will write
 // only music part without any ID3v2 information.
 func (t *Tag) Save() error {
+	if t.file == nil {
+		return fmt.Errorf("Parser not inited with file, it's just a stream")
+	}
+
 	// Get original file mode.
 	originalFile := t.file
 	originalStat, err := originalFile.Stat()
@@ -393,5 +400,9 @@ func writeFrameHeader(bw *bufio.Writer, id string, frameSize int) error {
 // Close closes t's file, rendering it unusable for I/O.
 // It returns an error, if any.
 func (t *Tag) Close() error {
+	if t.file == nil {
+		return fmt.Errorf("Parser not inited with file, it's just a stream")
+	}
+
 	return t.file.Close()
 }

--- a/tag.go
+++ b/tag.go
@@ -7,7 +7,6 @@ package id3v2
 import (
 	"bufio"
 	"errors"
-	"fmt"
 	"io"
 	"os"
 

--- a/tag.go
+++ b/tag.go
@@ -6,6 +6,7 @@ package id3v2
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -13,6 +14,8 @@ import (
 	"github.com/bogem/id3v2/bwpool"
 	"github.com/bogem/id3v2/util"
 )
+
+var ErrNoFile = errors.New("tag was not initialized with file")
 
 // Tag stores all information about opened tag.
 type Tag struct {
@@ -267,7 +270,7 @@ func (t *Tag) SetVersion(version byte) {
 // only music part without any ID3v2 information.
 func (t *Tag) Save() error {
 	if t.file == nil {
-		return fmt.Errorf("Parser not inited with file, it's just a stream")
+		return ErrNoFile
 	}
 
 	// Get original file mode.
@@ -401,7 +404,7 @@ func writeFrameHeader(bw *bufio.Writer, id string, frameSize int) error {
 // It returns an error, if any.
 func (t *Tag) Close() error {
 	if t.file == nil {
-		return fmt.Errorf("Parser not inited with file, it's just a stream")
+		return ErrNoFile
 	}
 
 	return t.file.Close()


### PR DESCRIPTION
Support for using a simple reader as source for the parser. The changes are backward compatible.