### PR TITLE
Write TerminationBytes for id3.org spec compliance

### DIFF
--- a/text_frame.go
+++ b/text_frame.go
@@ -14,13 +14,14 @@ type TextFrame struct {
 }
 
 func (tf TextFrame) Size() int {
-	return 1 + encodedSize(tf.Text, tf.Encoding)
+	return 1 + encodedSize(tf.Text, tf.Encoding) + len(tf.Encoding.TerminationBytes)
 }
 
 func (tf TextFrame) WriteTo(w io.Writer) (int64, error) {
 	return useBufWriter(w, func(bw *bufWriter) {
 		bw.WriteByte(tf.Encoding.Key)
 		bw.EncodeAndWriteText(tf.Text, tf.Encoding)
+		bw.Write(tf.Encoding.TerminationBytes)
 	})
 }
 


### PR DESCRIPTION
According to the spec http://id3.org/id3v2.4.0-structure,
TerminationBytes has to be in the text frame.
Some ID3 reader like Windows file explorer media file properties cannot handle such unicode text frames without proper TerminationBytes.


