### PR TITLE
add frame overflow check

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -15,6 +15,9 @@ const frameHeaderSize = 10
 var ErrUnsupportedVersion = errors.New("unsupported version of ID3 tag")
 var errBlankFrame = errors.New("id or size of frame are blank")
 
+// ErrBodyOverflow is returned when a frame has greater size than the remaining tag size
+var ErrBodyOverflow = errors.New("frame went over tag area")
+
 type frameHeader struct {
 	ID       string
 	BodySize int64
@@ -87,6 +90,9 @@ func (tag *Tag) parseFrames(opts Options) error {
 		id, bodySize := header.ID, header.BodySize
 
 		framesSize -= frameHeaderSize + bodySize
+		if framesSize < 0 {
+			return ErrBodyOverflow
+		}
 
 		bodyRd := getLimitedReader(tag.reader, bodySize)
 		defer putLimitedReader(bodyRd)


### PR DESCRIPTION
When I was working with a mp3 file today, I found a weird behavior that every time the tag was parsed and then saved, the file size got bigger but the metadata doesn't seem to be added. `id3v2` didn't give out any warning with a corrupt file but I think there should be. I investigated on that file and found that the claimed tag size was 2 bytes bigger than the actual one, which would cause `id3v2` to attempt to parse another unexisting tag which would lead to strange behaviors.

I added a check while parsing headers to prevent such overflow which might lead to an unexpected panic(reading over EOF)