### PR TITLE
Remove spurious the EOF test from parseFrames().

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -121,10 +121,6 @@ func (tag *Tag) parseFrames(opts Options) error {
 				break
 			}
 		}
-
-		if err == io.EOF {
-			break
-		}
 	}
 
 	return nil


### PR DESCRIPTION
I bumped in a bug where you read the `APIC` type from the `br` reader and return the final _error_ which happens to be an `EOF`.

You correctly ignore the `EOF` just after the call to the `APIC` function, however, later on you would check that error again and if `EOF` you would return early on. The result being that you miss all the data after the `APIC` frame. I have a test which generates random ID3 to make sure my application works as expected, and I bumped in this bug because of this bug. The 10 frames I have in that file would be ignored by your reader.

The `EOF`  test you have at the beginning of the loop are enough to make sure you exit on `EOF`. And the loop should otherwise be exited only once you read the number of bytes available in the ID3 and that's done very well with the `for framesSize > 0 {` line.