### PR TITLE
Put bufWriter in encodedSize

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -105,6 +105,8 @@ func encodedSize(src string, enc Encoding) int {
 	}
 
 	bw := getBufWriter(ioutil.Discard)
+	defer putBufWriter(bw)
+
 	encodeWriteText(bw, src, enc)
 
 	return bw.Written()


### PR DESCRIPTION
```
name                   old time/op    new time/op    delta
ParseAllFrames-4         72.0µs ± 1%    72.6µs ± 1%     ~     (p=0.065 n=6+6)
ParseAllFramesISO-4      74.7µs ± 5%    74.4µs ± 2%     ~     (p=1.000 n=7+7)
ParseArtistAndTitle-4    2.35µs ±17%    2.48µs ±14%     ~     (p=0.383 n=7+7)
Write-4                  5.42µs ± 1%    5.45µs ± 2%     ~     (p=0.421 n=6+7)
WriteISO-4               21.7µs ± 1%     9.3µs ± 1%  -57.01%  (p=0.001 n=7+7)

name                   old alloc/op   new alloc/op   delta
ParseAllFrames-4          262kB ± 0%     262kB ± 0%     ~     (p=0.643 n=7+7)
ParseAllFramesISO-4       262kB ± 0%     262kB ± 0%     ~     (p=0.833 n=7+7)
ParseArtistAndTitle-4      938B ± 1%      942B ± 1%     ~     (p=0.329 n=7+7)
Write-4                  1.38kB ± 0%    1.38kB ± 0%     ~     (all equal)
WriteISO-4               47.2kB ± 0%     5.2kB ± 0%  -88.93%  (p=0.001 n=7+7)

name                   old allocs/op  new allocs/op  delta
ParseAllFrames-4           56.0 ± 0%      56.0 ± 0%     ~     (all equal)
ParseAllFramesISO-4        61.0 ± 0%      61.0 ± 0%     ~     (all equal)
ParseArtistAndTitle-4      16.1 ±12%      16.7 ±10%     ~     (p=0.408 n=7+7)
Write-4                    26.0 ± 0%      26.0 ± 0%     ~     (all equal)
WriteISO-4                 71.0 ± 0%      41.0 ± 0%  -42.25%  (p=0.001 n=7+7)
```