### PR TITLE
fix invalid comparison causing errors opening frame

### DIFF
--- a/v2/parse.go
+++ b/v2/parse.go
@@ -5,6 +5,7 @@
 package id3v2
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -145,17 +146,17 @@ func parseFrameHeader(buf []byte, rd io.Reader, synchSafe bool) (frameHeader, er
 		return header, err
 	}
 
-	id := string(fhBuf[:4])
+	id := fhBuf[:4]
 	bodySize, err := parseSize(fhBuf[4:8], synchSafe)
 	if err != nil {
 		return header, err
 	}
 
-	if id == "" || bodySize == 0 {
+	if bytes.Equal(id, []byte{0, 0, 0, 0}) || bodySize == 0 {
 		return header, errBlankFrame
 	}
 
-	header.ID = id
+	header.ID = string(id)
 	header.BodySize = bodySize
 	return header, nil
 }


### PR DESCRIPTION
I noticed that after modifying tags in foobar2000 that `Open()` would fail with the following error:
`frame went over tag area`
This was due to foobar2000 truncating the padding after the final frame and reading the audio data as the next frame size. The `id == ""` check should have caught this, but even though []byte{0, 0, 0, 0} will be printed as an empty string, [it is not equivalent](https://play.golang.com/p/tcKUKblHYSr).