### PR TITLE
Add chapter picture frame

### DIFF
--- a/v2/chapter_frame.go
+++ b/v2/chapter_frame.go
@@ -25,6 +25,7 @@ type ChapterFrame struct {
 	EndOffset   uint32
 	Title       *TextFrame
 	Description *TextFrame
+	Artwork     *PictureFrame
 }
 
 func (cf ChapterFrame) Size() int {
@@ -91,6 +92,7 @@ func parseChapterFrame(br *bufReader, version byte) (Framer, error) {
 
 	var title TextFrame
 	var description TextFrame
+	var artwork PictureFrame
 
 	// borrowed from parse.go
 	buf := getByteSlice(32 * 1024)
@@ -121,6 +123,17 @@ func parseChapterFrame(br *bufReader, version byte) (Framer, error) {
 
 			putLimitedReader(bodyRd)
 		}
+		if id == "APIC" {
+			bodyRd := getLimitedReader(br, bodySize)
+			br := newBufReader(bodyRd)
+			frame, err := parsePictureFrame(br, version)
+			if err != nil {
+				putLimitedReader(bodyRd)
+				return nil, err
+			}
+			artwork = frame.(PictureFrame)
+			putLimitedReader(bodyRd)
+		}
 	}
 
 	cf := ChapterFrame{
@@ -133,6 +146,7 @@ func parseChapterFrame(br *bufReader, version byte) (Framer, error) {
 		EndOffset:   endOffset,
 		Title:       &title,
 		Description: &description,
+		Artwork:     &artwork,
 	}
 	return cf, nil
 }

--- a/v2/chapter_frame.go
+++ b/v2/chapter_frame.go
@@ -25,6 +25,7 @@ type ChapterFrame struct {
 	EndOffset   uint32
 	Title       *TextFrame
 	Description *TextFrame
+	Link        *LinkFrame
 	Artwork     *PictureFrame
 }
 
@@ -92,6 +93,7 @@ func parseChapterFrame(br *bufReader, version byte) (Framer, error) {
 
 	var title TextFrame
 	var description TextFrame
+	var link LinkFrame
 	var artwork PictureFrame
 
 	// borrowed from parse.go
@@ -123,6 +125,18 @@ func parseChapterFrame(br *bufReader, version byte) (Framer, error) {
 
 			putLimitedReader(bodyRd)
 		}
+		if id == "WXXX" {
+			bodyRd := getLimitedReader(br, bodySize)
+			br := newBufReader(bodyRd)
+			frame, err := parseLinkFrame(br)
+			if err != nil {
+				putLimitedReader(bodyRd)
+				return nil, err
+			}
+			link = frame.(LinkFrame)
+
+			putLimitedReader(bodyRd)
+		}
 		if id == "APIC" {
 			bodyRd := getLimitedReader(br, bodySize)
 			br := newBufReader(bodyRd)
@@ -146,6 +160,7 @@ func parseChapterFrame(br *bufReader, version byte) (Framer, error) {
 		EndOffset:   endOffset,
 		Title:       &title,
 		Description: &description,
+		Link:        &link,
 		Artwork:     &artwork,
 	}
 	return cf, nil

--- a/v2/link_frame.go
+++ b/v2/link_frame.go
@@ -1,0 +1,52 @@
+// Copyright 2016 Albert Nigmatzianov. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package id3v2
+
+import "io"
+
+type LinkFrame struct {
+	Encoding Encoding
+	Url      string
+}
+
+func (tf LinkFrame) Size() int {
+	return 1 + encodedSize(tf.Url, tf.Encoding) + len(tf.Encoding.TerminationBytes)
+}
+
+func (tf LinkFrame) UniqueIdentifier() string {
+	return "ID"
+}
+
+func (tf LinkFrame) WriteTo(w io.Writer) (int64, error) {
+	return useBufWriter(w, func(bw *bufWriter) {
+		bw.WriteByte(tf.Encoding.Key)
+		bw.EncodeAndWriteText(tf.Url, tf.Encoding)
+
+		// https://github.com/bogem/id3v2/pull/52
+		// https://github.com/bogem/id3v2/pull/33
+		bw.Write(tf.Encoding.TerminationBytes)
+	})
+}
+
+func parseLinkFrame(br *bufReader) (Framer, error) {
+	encoding := getEncoding(br.ReadByte())
+
+	if br.Err() != nil {
+		return nil, br.Err()
+	}
+
+	buf := getBytesBuffer()
+	defer putBytesBuffer(buf)
+	if _, err := buf.ReadFrom(br); err != nil {
+		return nil, err
+	}
+
+	lf := LinkFrame{
+		Encoding: encoding,
+		Url:      decodeText(buf.Bytes(), encoding),
+	}
+
+	return lf, nil
+}

--- a/v2/link_frame.go
+++ b/v2/link_frame.go
@@ -11,22 +11,22 @@ type LinkFrame struct {
 	Url      string
 }
 
-func (tf LinkFrame) Size() int {
-	return 1 + encodedSize(tf.Url, tf.Encoding) + len(tf.Encoding.TerminationBytes)
+func (lf LinkFrame) Size() int {
+	return 1 + encodedSize(lf.Url, lf.Encoding) + len(lf.Encoding.TerminationBytes)
 }
 
-func (tf LinkFrame) UniqueIdentifier() string {
+func (lf LinkFrame) UniqueIdentifier() string {
 	return "ID"
 }
 
-func (tf LinkFrame) WriteTo(w io.Writer) (int64, error) {
+func (lf LinkFrame) WriteTo(w io.Writer) (int64, error) {
 	return useBufWriter(w, func(bw *bufWriter) {
-		bw.WriteByte(tf.Encoding.Key)
-		bw.EncodeAndWriteText(tf.Url, tf.Encoding)
+		bw.WriteByte(lf.Encoding.Key)
+		bw.EncodeAndWriteText(lf.Url, lf.Encoding)
 
 		// https://github.com/bogem/id3v2/pull/52
 		// https://github.com/bogem/id3v2/pull/33
-		bw.Write(tf.Encoding.TerminationBytes)
+		bw.Write(lf.Encoding.TerminationBytes)
 	})
 }
 


### PR DESCRIPTION
This allows to get the image from the chapter, useful for podcasts.

```go
chapters := tag.GetFrames(tag.CommonID("Chapters"))
for _, f := range chapters {
    chapter, ok := f.(id3v2.ChapterFrame)
    if !ok {
        log.Fatal("Couldn't get chapter")
    }
    fmt.Println(chapter.Title.Text)
    fmt.Println(chapter.Artwork.MimeType)
    // If a chapter doesn't have an image, use the default artwork
}
```